### PR TITLE
build: drop cuda label from windows runs-on

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,7 +230,7 @@ jobs:
   build-windows:
     name: Windows ${{ matrix.package }} py${{ matrix.python }} cu${{ matrix.cuda_short }} torch${{ matrix.pytorch }}
     needs: generate-matrix
-    runs-on: ${{ inputs.runner == 'self-hosted' && fromJson('["self-hosted","windows","cuda"]') || 'windows-2022' }}
+    runs-on: ${{ inputs.runner == 'self-hosted' && fromJson('["self-hosted","windows"]') || 'windows-2022' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix).windows }}


### PR DESCRIPTION
Windows runners are now registered with simplified labels `self-hosted,windows` only. The `cuda` label is scoped to comfy-gpu-ci runners. Drops the unused `cuda` constraint from the Windows build matrix so jobs bind to the new runner labels.