### PR TITLE
build: powershell instead of pwsh on debug step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,7 @@ jobs:
     steps:
 
       - name: Runner identity (debug)
-        shell: pwsh
+        shell: powershell
         run: |
           echo "runner.name=${{ runner.name }} runner.os=${{ runner.os }} hostname=$env:COMPUTERNAME user=$(whoami)"
           echo "--- whoami /groups ---"


### PR DESCRIPTION
Self-hosted runner doesn't have PowerShell 7. Use built-in powershell 5.1.